### PR TITLE
use a concrete type for the type parameter

### DIFF
--- a/src/Fields.jl
+++ b/src/Fields.jl
@@ -3,4 +3,6 @@ module Fields
 include("physicalfield.jl")
 include("spectrafield.jl")
 
+export PhysicalField, SpectralField
+
 end

--- a/src/physicalfield.jl
+++ b/src/physicalfield.jl
@@ -1,18 +1,18 @@
 # This file contains the custom type to define a scalar field in physical space
 # for a rotating plane couette flow.
 
-struct PhysicalField{Ny, Nz, Nt, T} <: AbstractArray{T, 3}
-    data::AbstractArray{T, 3}
-
+struct PhysicalField{Ny, Nz, Nt, T, A<:AbstractArray{T, 3}} <: AbstractArray{T, 3}
+    data::A
     # construct from size and type
     function PhysicalField(Ny::Int, Nz::Int, Nt::Int, ::Type{T}=Float64) where {T<:Real}
-        new{Ny, Nz, Nt, T}(zeros(Ny, Nz, Nt))
+        data = zeros(Ny, Nz, Nt)
+        new{Ny, Nz, Nt, T, typeof(data)}(data)
     end
 
     # construct from data
-    function PhysicalField(v::V) where {T<:Real, V<:AbstractArray{T, 3}}
-        shape = size(v)
-        new{shape[1], shape[2], shape[3], T}(v)
+    function PhysicalField(data::A) where {T<:Real, A<:AbstractArray{T, 3}}
+        shape = size(data)
+        new{shape[1], shape[2], shape[3], T, A}(data)
     end
 end
 

--- a/src/spectrafield.jl
+++ b/src/spectrafield.jl
@@ -5,23 +5,24 @@
 # TODO: Transform between spectral and physical space
 # TODO: Grid object to make the discretisation explicit (not completely necessary unless I want to change the discretisation?)
 
-struct SpectraField{Ny, Nz, Nt, T} <: AbstractArray{Complex{T}, 3}
-    data::AbstractArray{Complex{T}, 3}
+struct SpectralField{Ny, Nz, Nt, T, A<:AbstractArray{Complex{T}, 3}} <: AbstractArray{Complex{T}, 3}
+    data::A
 
     # constrcut from size and type
-    function SpectraField(Ny::Int, Nz::Int, Nt::Int, ::Type{T}=Float64) where {T}
-        new{Ny, Nz, Nt, T}(zeros(Ny, Nz, Nt))
+    function SpectralField(Ny::Int, Nz::Int, Nt::Int, ::Type{T}=Float64) where {T}
+        data = zeros(Complex{T}, Ny, Nz, Nt)
+        new{Ny, Nz, Nt, T, typeof(data)}(data)
     end
 
     # construct from data
-    function SpectraField(v::V) where {T, V<:Union{AbstractArray{Complex{T}, 3}, AbstractArray{T, 3}}}
-        shape = size(v)
-        new{shape[1], shape[2], shape[3], T}(v)
+    function SpectralField(data::A) where {T, A<:AbstractArray{Complex{T}, 3}}
+        shape = size(data)
+        new{shape[1], shape[2], shape[3], T, A}(dara)
     end
 end
 
 # define interface
-Base.size(::SpectraField{Ny, Nz, Nt}) where {Ny, Nz, Nt} = (Ny, Nz, Nt)
-Base.IndexStyle(::Type{<:SpectraField}) = Base.IndexLinear()
-Base.getindex(u::SpectraField, i::Int) = u.data[i]
-Base.setindex!(u::SpectraField, v, i::Int) = (u.data[i] = v)
+Base.size(::SpectralField{Ny, Nz, Nt}) where {Ny, Nz, Nt} = (Ny, Nz, Nt)
+Base.IndexStyle(::Type{<:SpectralField}) = Base.IndexLinear()
+Base.getindex(u::SpectralField, i::Int) = u.data[i]
+Base.setindex!(u::SpectralField, v, i::Int) = (u.data[i] = v)


### PR DESCRIPTION
You need to use a concrete type for the fields of any structs.

Consider this code, where a function `foo!` is defined that does a simple broadcasting operation on three `SpectralField`s

```julia
using Fields

# test broadcasting speed 

Ny = 61
Nz = 32
Nt = 64

a = SpectralField(Ny, Nz, Nt)
b = SpectralField(Ny, Nz, Nt)
c = SpectralField(Ny, Nz, Nt)

foo!(a, b, c) = (a .= 3 .* b .+ c ./ 2)

@time foo!(a, b, c)
@time foo!(a, b, c)
@time foo!(a, b, c)
@time foo!(a, b, c)
```

With the old version
```
  0.304640 seconds (2.63 M allocations: 91.983 MiB, 5.44% gc time, 88.78% compilation time)
  0.037871 seconds (1.37 M allocations: 20.938 MiB)
  0.039140 seconds (1.37 M allocations: 20.938 MiB, 24.90% gc time)
  0.026934 seconds (1.37 M allocations: 20.938 MiB)
```

with the new version
```
  0.236515 seconds (1.29 M allocations: 71.866 MiB, 9.18% gc time, 99.72% compilation time)
  0.000498 seconds
  0.000304 seconds
  0.000356 seconds
```
i.e. a speed up of 100x!
